### PR TITLE
Made openbrowser.sh more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,4 @@ Find a compiled version [here](https://gultsch.de/ImageDownloader-0.1.jar)
 
 Usage: ```java -jar ImageDownloader.jar http://host.tld/path/to/file.jpg#theivandkey```
 
-If you change your browser in gajim to something like this script it will automatically open image links in your image viewer if you click on them.
-```
-#!/bin/bash
-URL=$1
-BROWSER=firefox
-JAVA=/usr/lib/jvm/java-8-openjdk/bin/java
-IMAGE_DOWNLOADER=/home/daniel/Projects/ImageDownloader/t
-if [ ${URL: -97:1} == "#" ]; then
-	$JAVA -jar $IMAGE_DOWNLOADER $URL | feh -. -
-else
-   $BROWSER $URL
-```
+If you change your browser in gajim to something like the `openbrowser.sh` script it will automatically open image links in your image viewer if you click on them.

--- a/openbrowser.sh
+++ b/openbrowser.sh
@@ -5,6 +5,8 @@ JAVA=/usr/lib/jvm/java-8-openjdk/bin/java
 IMAGE_DOWNLOADER=/home/daniel/Projects/ImageDownloader/target/ImageDownloader-0.1.jar
 if [ ${URL: -97:1} == "#" ]; then
 	$JAVA -jar $IMAGE_DOWNLOADER $URL | feh -. -
+elif $(echo ${URL##*.} | tr '[:upper:]' '[:lower:]' | grep 'png\|jpg' &>/dev/null); then
+    feh $URL
 else
    $BROWSER $URL
 fi

--- a/openbrowser.sh
+++ b/openbrowser.sh
@@ -5,6 +5,7 @@ BROWSER=xdg-open
 JAVA=/usr/lib/jvm/java-default-runtime/bin/java
 IMAGE_DOWNLOADER=${DIR}/target/ImageDownloader-0.1.jar
 
+if [ "${URL: -97:1}" == "#" ]; then
 	$JAVA -jar $IMAGE_DOWNLOADER $URL | feh -. -
 elif $(echo ${URL##*.} | tr '[:upper:]' '[:lower:]' | grep 'png\|jpg' &>/dev/null); then
     feh $URL

--- a/openbrowser.sh
+++ b/openbrowser.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 URL=$1
-BROWSER=firefox
-JAVA=/usr/lib/jvm/java-8-openjdk/bin/java
-IMAGE_DOWNLOADER=/home/daniel/Projects/ImageDownloader/target/ImageDownloader-0.1.jar
-if [ ${URL: -97:1} == "#" ]; then
+BROWSER=xdg-open
+JAVA=/usr/lib/jvm/java-default-runtime/bin/java
+IMAGE_DOWNLOADER=${DIR}/target/ImageDownloader-0.1.jar
+
 	$JAVA -jar $IMAGE_DOWNLOADER $URL | feh -. -
 elif $(echo ${URL##*.} | tr '[:upper:]' '[:lower:]' | grep 'png\|jpg' &>/dev/null); then
     feh $URL


### PR DESCRIPTION
The changes in this pull request add some flexibility to the `openbrowser.sh` script.

- "normal" unencrypted links are handled (at least for .png and .jpg files)
- The configuration paths have been changed so that default applications / paths are used.

Furthermore, a small issue with the '=='-operator in the if statement was fixed and the readme was updated.